### PR TITLE
SEL-8698: Integer to time conversion

### DIFF
--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -44,7 +44,7 @@ module Devise
             drift_ahead: drift, drift_behind: drift, after: totp_timestamp
           )
           return false unless new_timestamp
-          self.totp_timestamp = new_timestamp.is_a?(Integer) ? Time.zone.at(new_timestamp) : new_timestamp
+          self.totp_timestamp = Time.zone.at(new_timestamp)
           true
         end
 

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -44,7 +44,7 @@ module Devise
             drift_ahead: drift, drift_behind: drift, after: totp_timestamp
           )
           return false unless new_timestamp
-          self.totp_timestamp = new_timestamp
+          self.totp_timestamp = new_timestamp.is_a?(Integer) ? Time.zone.at(new_timestamp) : new_timestamp
           true
         end
 


### PR DESCRIPTION
Storing the timestamp has never worked in our case, adding an integer to the field converted it to nil until Rails 8.

The value conversion in ActiveRecord has changed to not return nil but the original value in Rails 8.

https://github.com/rails/rails/commit/e875b2df0147b12d129ecce763c9cd5cd7ef8862 that makes persisting the value fail on save.

Related to https://github.com/selma-finance/warren/pull/10159